### PR TITLE
add support for openbay-dump-db

### DIFF
--- a/api/torrentdb.go
+++ b/api/torrentdb.go
@@ -19,6 +19,7 @@ type Torrent struct {
 	Btih     string `bson:"_id,omitempty"`
 	Title    string
 	Category string
+	Size int
 	Details  []string
 	Download []string
 	Swarm    Stats
@@ -122,11 +123,12 @@ func (torrentDB *TorrentDB) Get(r render.Render, params martini.Params) {
 	r.JSON(200, result)
 }
 
-func (torrentDB *TorrentDB) Insert(btih string, title string, category string, details string, download string) (bool, error) {
+func (torrentDB *TorrentDB) Insert(btih string, title string, category string, size int, details string, download string) (bool, error) {
 	err := torrentDB.collection.Insert(
 		&Torrent{Btih: btih,
 			Title:    title,
 			Category: category,
+			Size: size,
 			Details:  []string{details},
 			Download: []string{download},
 			Swarm:    Stats{Seeders: -1, Leechers: -1},


### PR DESCRIPTION
I added the support for openbay dump. It's working on my computer. I also added "Size" into the database. It's a little bit quick and dirty, it will be good to add column name into the csv then parse it. Or it may be useless if the structure is always the same.

Just an idea, reject the request if you already know a better way to do that :)