### PR TITLE
Add support for an optional localUdpPort config entry for NAT users and ...

### DIFF
--- a/api/bitcannon.go
+++ b/api/bitcannon.go
@@ -11,6 +11,7 @@ import (
 type Config struct {
 	ScrapeEnabled bool
 	ScrapeDelay   int
+	LocalUdpPort  int
 }
 
 var config = Config{ScrapeEnabled: false, ScrapeDelay: 0}
@@ -61,6 +62,15 @@ func main() {
 			if err == nil {
 				config.ScrapeDelay = int(scrapeDelay)
 			}
+			// Get localUdpPort if it exists:
+			localUdpPort, err := json.GetInt64("localUdpPort")
+			if err == nil {
+				config.LocalUdpPort = int(localUdpPort)
+			} else {
+				config.LocalUdpPort = 0
+			}
+		} else {
+			log.Printf("[!!!] JSON err: %v", err)
 		}
 	}
 	// Try to connect to the database

--- a/api/scrape.go
+++ b/api/scrape.go
@@ -8,7 +8,7 @@ import (
 )
 
 func scrapeWorker() {
-	bulk := goscrape.NewBulk(trackers)
+	bulk := goscrape.NewBulk(trackers, config.LocalUdpPort)
 	for {
 		stale := torrentDB.GetStale()
 		if len(stale) > 1 {
@@ -28,7 +28,7 @@ func multiUpdate(results []goscrape.Result) {
 }
 
 func apiScrape(r render.Render, params martini.Params) {
-	result := goscrape.Single(trackers, []string{params["btih"]})[0]
+	result := goscrape.Single(trackers, []string{params["btih"]}, config.LocalUdpPort)[0]
 	multiUpdate([]goscrape.Result{result})
 	r.JSON(200, map[string]interface{}{"Swarm": map[string]interface{}{"Seeders": result.Seeders, "Leechers": result.Leechers}, "Lastmod": time.Now()})
 }


### PR DESCRIPTION
...pass it to goscrape.

I didn't supply the config.json edit since my local .json file is the one I use to run bitcannon with.

Bill
