### PR TITLE
Add an option to configure bitcannon binding IP

### DIFF
--- a/api/bitcannon.go
+++ b/api/bitcannon.go
@@ -25,6 +25,7 @@ func main() {
 	// Get mongo url from config.json, otherwise default to 127.0.0.1
 	mongo := "127.0.0.1"
 	bitcannonPort := "1337"
+	bitcannonBindIp := "0.0.0.0"
 	f, err := ioutil.ReadFile("config.json")
 	if err != nil {
 		log.Println("[!!!] Config not loaded")
@@ -61,6 +62,11 @@ func main() {
 			if err == nil {
 				config.ScrapeDelay = int(scrapeDelay)
 			}
+			// Get desired listening host
+			val, err = json.GetString("bitcannonBindIp")
+			if err == nil {
+				bitcannonBindIp = val
+			}
 		}
 	}
 	// Try to connect to the database
@@ -77,16 +83,16 @@ func main() {
 		importFile(os.Args[1])
 		enterExit()
 	} else {
-		runServer(bitcannonPort)
+		runServer(bitcannonPort, bitcannonBindIp)
 	}
 }
 
-func runServer(bitcannonPort string) {
+func runServer(bitcannonPort string, bitcannonBindIp string) {
 	log.Println("[OK!] BitCannon is live at http://127.0.0.1:" + bitcannonPort + "/")
 	api := NewAPI()
 	api.AddRoutes()
 	runScheduler()
-	api.Run(":" + bitcannonPort)
+	api.Run(bitcannonBindIp + ":" + bitcannonPort)
 }
 
 func enterExit() {

--- a/api/config.json
+++ b/api/config.json
@@ -1,5 +1,6 @@
 {
   "mongo": "127.0.0.1",
+  "bitcannonBindIp": "0.0.0.0",
   "bitcannonPort": "1337",
   "scrapeEnabled": true,
   "scrapeDelay": 0,


### PR DESCRIPTION
This PR makes it possible to configure bitcannon's web server binding address.

I think it can be useful to restrict the binding address of the server for several reasons, starting with security.

To avoid BC breaks, I set it to 0.0.0.0 in the default config and fallback in the code. But I think its default value should be 127.0.0.1.