### PR TITLE
Added Category Blacklist Feature

### DIFF
--- a/api/bitcannon.go
+++ b/api/bitcannon.go
@@ -15,6 +15,7 @@ type Config struct {
 
 var config = Config{ScrapeEnabled: false, ScrapeDelay: 0}
 var trackers []string
+var blacklistedCategories []string
 var archives []*jason.Object
 var torrentDB *TorrentDB
 var err error
@@ -51,6 +52,11 @@ func main() {
 			trac, err := json.GetStringArray("trackers")
 			if err == nil {
 				trackers = trac
+			}
+			// Get blacklisted categories
+			blackCats, err := json.GetStringArray("blacklisted_categories")
+			if err == nil {
+				blacklistedCategories = blackCats
 			}
 			// Get scraping enabled
 			scrape, err := json.GetBoolean("scrapeEnabled")

--- a/api/config.json
+++ b/api/config.json
@@ -8,6 +8,10 @@
     "udp://tracker1.com:80",
     "udp://tracker2.com:1337"
   ],
+  "blacklisted_categories": [
+    "Category to blacklist 1",
+    "Category to blacklist 2"
+  ],
   "archives": [{
     "name": "Site1",
     "url": "http://site1.com/archive.txt.gz",

--- a/api/import.go
+++ b/api/import.go
@@ -133,7 +133,11 @@ func importLine(line string) (bool, error) {
 		if data[2] == "" {
 			data[2] = "Other"
 		}
-		return torrentDB.Insert(data[0], data[1], data[2], 0, data[3])
+		if (!categoryInBlacklisted(data[2],blacklistedCategories)) {
+			return torrentDB.Insert(data[0], data[1], data[2], 0, data[3])
+		} else {
+			return false, errors.New("Skipping torrent due to category "+data[2]+" in blacklist")
+		}
 	} else if strings.Count(line, "|") == 6 {
 		data := strings.Split(line, "|")
 		if len(data[2]) != 40 {
@@ -143,8 +147,22 @@ func importLine(line string) (bool, error) {
 			data[4] = "Other"
 		}
 		size, _ = strconv.Atoi(data[1])
-		return torrentDB.Insert(data[2], data[0], data[4], size, "")
+		if (!categoryInBlacklisted(data[4],blacklistedCategories)) {
+			return torrentDB.Insert(data[2], data[0], data[4], size, "")
+		} else {
+			return false, errors.New("Skipping torrent due to category "+data[4]+" in blacklist")
+		}
 	} else {
 		return false, errors.New("Something's up with this torrent.")
 	}
+}
+
+//http://stackoverflow.com/questions/15323767/how-to-if-x-in-array-in-golang
+func categoryInBlacklisted(a string, list []string) bool {
+    for _, b := range list {
+        if b == a {
+            return true
+        }
+    }
+    return false
 }


### PR DESCRIPTION
Some users might not want to blanket add all torrents to their database so I've added a category blacklist feature to exclude torrents of certain categories. The feature is case sensitive i.e myCategory is not the same as MYCATEGORY. Enhancements could be made to support more filtering perhaps through the use of wildcards and regular expressions.

Configuration is done in the config.json file as follows:

"blacklisted_categories": [

"Category to blacklist 1",

"Category to blacklist 2"

]