### PR TITLE
Add crypto/sha512 to imports to support newer certificates

### DIFF
--- a/api/import.go
+++ b/api/import.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	_ "crypto/sha512"
 )
 
 func importScheduler() {


### PR DESCRIPTION
Bitcannon failed to get torrents from Yify (cf issue https://github.com/Stephen304/bitcannon/issues/84).

Thanks to [this post](http://bridge.grumpy-troll.org/2014/05/golang-tls-comodo/), I found that newer certificates required an additional crypto library. 